### PR TITLE
Implement Two-Factor Authentication by Device Token

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -8,6 +8,8 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from two_factor.forms import TOTPDeviceForm
 from two_factor.utils import totp_digits
 
+from apps.users.models import Profile
+
 
 class UserRegisterForm(UserCreationForm):
     email = forms.EmailField()

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -1,8 +1,12 @@
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
+from django.utils.translation import gettext_lazy as _
 
-from apps.users.models import Profile
+from crispy_forms.helper import FormHelper
+from django_otp.plugins.otp_totp.models import TOTPDevice
+from two_factor.forms import TOTPDeviceForm
+from two_factor.utils import totp_digits
 
 
 class UserRegisterForm(UserCreationForm):
@@ -63,3 +67,46 @@ class ProfileUpdateForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+
+class UserTOTPDeviceForm(TOTPDeviceForm):
+
+    token = forms.IntegerField(label=_("Token"), min_value=0, max_value=int('9' * totp_digits()))
+
+    def __init__(self, key, user, metadata=None, **kwargs):
+        super().__init__(self, key, user, **kwargs)
+        self.key = key
+        self.tolerance = 1
+        self.t0 = 0
+        self.step = 30
+        self.drift = 0
+        self.digits = totp_digits()
+        self.user = user
+        self.metadata = metadata or {}
+
+        self.helper = FormHelper()
+        self.fields['token'].label = False
+        self.fields["token"].widget.attrs={
+            "autofocus": "autofocus",
+            "inputmode": "numeric",
+            "autocomplete": "one-time-code",
+            "class": "form-control",
+            "placeholder": "Enter token from authenticator app...",
+        }
+
+    def clean_token(self):
+        return self.cleaned_data['token']
+
+    def save(self):
+        return TOTPDevice.objects.create(
+            user=self.user,
+            key=self.key,
+            tolerance=self.tolerance,
+            t0=self.t0,
+            step=self.step,
+            drift=self.drift,
+            digits=self.digits,
+            name='default'
+        )
+
+

--- a/apps/users/templates/users/two_factor/setup.html
+++ b/apps/users/templates/users/two_factor/setup.html
@@ -28,11 +28,10 @@
         </p>
         <form action="" method="POST">
           {% csrf_token %}
-
-          <table class="mb-3">
+          <div class="mb-3">
             {{ wizard.form }}
             {{ wizard.management_form }}
-          </table>
+          </div>
 
           {# hidden submit button to enable [enter] key #}
           <input type="submit" value="" class="d-none" />

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -4,7 +4,7 @@ from django.urls import path, reverse_lazy
 from two_factor.views import QRGeneratorView
 
 from apps.users.views import (ProfileUpdateView, ProfileView, UserLoginView,
-                              UserRegisterView, UserSetupView,)
+                              UserSetupEmailView, UserSetupQRView,)
 
 
 app_name = 'users'
@@ -18,7 +18,7 @@ urlpatterns = [
 # Custom Login and Password Reset Process
 urlpatterns += [
     path('login/', UserLoginView.as_view(), name='login'),
-    path('two-factor/setup/', UserSetupView.as_view(), name='setup'),
+    path('two-factor/setup/qr/', UserSetupQRView.as_view(), name='setup'),
     path('two-factor/qrcode/', QRGeneratorView.as_view(), name='qr'),
     path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='logout'),
     path('password-reset/',

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -7,10 +7,10 @@ from django.urls import reverse_lazy
 from django.views.generic import CreateView, DetailView
 
 from shapeshifter.views import MultiModelFormView
-from two_factor.forms import AuthenticationTokenForm, TOTPDeviceForm
-from two_factor.views.core import LoginView, SetupCompleteView, SetupView
+from two_factor.forms import AuthenticationTokenForm
+from two_factor.views.core import LoginView, SetupView
 
-from apps.users.forms import ProfileUpdateForm, UserRegisterForm, UserUpdateForm
+                              UserRegisterForm, UserTOTPDeviceForm, UserUpdateForm,)
 from apps.users.models import Profile
 
 
@@ -55,12 +55,12 @@ class UserLoginView(LoginView):
     )
 
 
-class UserSetupView(SetupView):
+class UserSetupQRView(SetupView):
     template_name = 'two_factor/setup.html'
     success_url = 'blog:home'
 
     form_list = (
-        ('generator', TOTPDeviceForm),
+        ('generator', UserTOTPDeviceForm),
     )
     condition_dict = {
         'generator': lambda self: True,

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -10,7 +10,8 @@ from shapeshifter.views import MultiModelFormView
 from two_factor.forms import AuthenticationTokenForm
 from two_factor.views.core import LoginView, SetupView
 
-                              UserRegisterForm, UserTOTPDeviceForm, UserUpdateForm,)
+from apps.users.forms import (ProfileUpdateForm, UserRegisterForm, UserTOTPDeviceForm,
+                              UserUpdateForm,)
 from apps.users.models import Profile
 
 


### PR DESCRIPTION
- Simply cleans the token and saves the device to the `otp_totp_device` table attributing the token to the user
- Subclasses TOTP Form from the `django-two-factor-auth` app to implement custom Crispy Forms behaviour, styling, etc.