### PR TITLE
Refactor 2FA Code for Token Implementation

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -95,20 +95,3 @@ class UserTOTPDeviceForm(TOTPDeviceForm):
             "class": "form-control",
             "placeholder": "Enter token from authenticator app...",
         }
-
-    def clean_token(self):
-        return self.cleaned_data['token']
-
-    def save(self):
-        return TOTPDevice.objects.create(
-            user=self.user,
-            key=self.key,
-            tolerance=self.tolerance,
-            t0=self.t0,
-            step=self.step,
-            drift=self.drift,
-            digits=self.digits,
-            name='default'
-        )
-
-


### PR DESCRIPTION
Addresses the following:

- Removes `clean` method since the parent class' method is the required
  implementation
- Removes the `save` method since the parent class has exactly the same
  implementation and therefore its presence in the class for the form is
  superfluous

Fixes: #95