### PR TITLE
Correct typo

### DIFF
--- a/apps/pages/templates/pages/skills/skill/pytest.html
+++ b/apps/pages/templates/pages/skills/skill/pytest.html
@@ -1,8 +1,9 @@
 <section class="project px-3 mb-3">
   <div class="container">
     <div class="project-meta media flex-column flex-md-row p-4 theme-bg-light">
-      <img class="project-thumb mb-3 mb-md-0 mr-md-5 rounded d-none d-md-inline-block" 
-        src="https://wl-portfolio.s3.eu-west-2.amazonaws.com/images/skills/pytest-coverage.png" alt="pytest">
+      <img class="project-thumb mb-3 mb-md-0 mr-md-5 rounded d-none d-md-inline-block"
+        src="https://wl-portfolio.s3.eu-west-2.amazonaws.com/images/skills/pytest-coverage.png" alt="pytest"
+      >
       <div class="media-body">
         <div class="client-info">
           <ul class="client-meta list-unstyled">
@@ -43,7 +44,7 @@
               change the test.
             </p>
             <p>
-              In addition, and certaintly where I have control of an external site's 404 breakages,
+              In addition, and certainly where I have control of an external site's 404 breakages,
               I test links to external websites. I learned this after a large restructuring exercise
               where I grouped apps into an 'apps' directory and ended up breaking a lot of the external
               links which should have enabled the user to navigate to the relevant source code page.


### PR DESCRIPTION
Addresses the following:

- Fixes spelling mistake for the word `certainly`
- Reformats the HTML for the template