### PR TITLE
Fix Avatars

### DIFF
--- a/apps/blog/templates/blog/components/meta_data.html
+++ b/apps/blog/templates/blog/components/meta_data.html
@@ -5,14 +5,14 @@
     <tbody>
       <tr>
         <td>
-          <img class="rounded-circle article-img" src="{{ author.user.profile_picture.url }}" />
+          <img class="rounded-circle article-img" src="{{ author.profile.profile_picture.url }}" />
         </td>
         <td>
           <ul class="no-bullets">
             <!-- Author Name or Username -->
             <li>
-              <a class="theme-link" href="{% url 'blog:author_posts' author.username %}">
-                {{ author.user.display_name }}
+              <a class="theme-link" href="{% url 'blog:author_posts' author.get_username %}">
+                <strong>{{ author.profile.display_name }}</strong>
               </a>
             </li>
 

--- a/apps/blog/templates/blog/components/post_card.html
+++ b/apps/blog/templates/blog/components/post_card.html
@@ -17,7 +17,9 @@
             <tr>
               <td>
                 <div class="mb-1">
-                  <a class="theme-link font-weight-bolder" href="{% url 'blog:author_posts' post.author.username %}">
+                  <a href="{% url 'blog:author_posts' post.author.get_username %}"
+                     class="theme-link font-weight-bolder"
+                  >
                     {{ post.author.profile.display_name }}
                   </a>
                 </div>

--- a/apps/blog/tests/test_views.py
+++ b/apps/blog/tests/test_views.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.django_db(reset_sequences=True)
     argvalues=[pytest.param('auth_user'), pytest.param('unauth_user')], indirect=True)
 class TestHomeView:
     def test_all_users_can_access(self, rf, all_users):
-        """ 
+        """
         Asserts authenticated and unauthenticated user can access
         complete list of posts
         """
@@ -31,7 +31,7 @@ class TestAuthorPostListView:
         Asserts authenticated and unauthenticated user can access
         list of posts written by another author
         """
-        author_username = pub_posts[0].author.username
+        author_username = pub_posts[0].author.get_username()
         kwargs = {'username': author_username}
         path = reverse('blog:author_posts', kwargs=kwargs)
         request = rf.get(path)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = aa_project.settings.pytest.pytest
 django_find_project = true
 
 python_paths =


### PR DESCRIPTION
Avatars are not being displayed correctly since the change of the related name from `users` to `profile`.

Also pytest config and unit test slighty modified.